### PR TITLE
Update-workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions' # See documentation for possible values
+    directory: '/' # Location of package manifests
+    schedule:
+      interval: 'weekly'

--- a/.github/workflows/bicep_test_and_deploy.yml
+++ b/.github/workflows/bicep_test_and_deploy.yml
@@ -10,6 +10,12 @@ on:
     paths:
       - "**/*.bicep"
       - "**/*.bicepparam"
+      - '.github/workflows/bicep_test_and_deploy.yml'
+      - '.github/workflows/bicep_verify.yml'
+      - '.github/workflows/bicep_create_matrix.yml'
+      - '.github/workflows/scripts/bicep_matrix.sh'
+      - '.github/actions/bicep_lint/action.yml'
+      - '.github/actions/bicep_validate/action.yml'
     types: [opened, synchronize, edited, ready_for_review]
   workflow_dispatch:
 

--- a/.github/workflows/bicep_test_and_deploy.yml
+++ b/.github/workflows/bicep_test_and_deploy.yml
@@ -1,4 +1,4 @@
-name: bicep
+name: bicep - validate and deploy
 on:
   push:
     branches: [main, develop]
@@ -19,6 +19,7 @@ jobs:
     uses: ./.github/workflows/bicep_create_matrix.yml
 
   verify:
+    if: github.event_name == 'pull_request'
     needs: matrix-output
     strategy:
       matrix: ${{ fromJson(needs.matrix-output.outputs.matrix) }}
@@ -31,3 +32,25 @@ jobs:
       login: true
     secrets:
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+
+  deploy:
+    name: Deployment
+    if: github.event_name == 'push'
+    needs: matrix-output
+    strategy:
+      matrix: ${{ fromJson(needs.matrix-output.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - id: deploy
+        name: deploy ${{ matrix.name }}
+        uses: ./.github/actions/bicep_validate
+        with:
+          bicepFilePath: ./${{ matrix.path }}/${{ matrix.template }}
+          bicepParameters: ./${{ matrix.path }}/${{ matrix.parameters }}
+          deploymentScope: sub
+          deploymentType: what-if # placeholder for now
+          deploymentLocation: westeurope


### PR DESCRIPTION
set `bicep - validate and deploy` to only verify PRs, while pushes (merges) to main / develop with updates to the templates will directly get deployed to not block runners longer as necessary.

also add dependabot